### PR TITLE
base64 pdf

### DIFF
--- a/HTMLToPDFExample/index.ios.js
+++ b/HTMLToPDFExample/index.ios.js
@@ -4,22 +4,22 @@
  */
 'use strict';
 
-var React = require('react-native');
+import React, { Component } from 'react';
 
-var {
-  AlertIOS,
+import {
   AppRegistry,
   StyleSheet,
+  AlertIOS,
   Text,
   View,
-} = React;
+} from 'react-native';
 
 import RNHTMLtoPDF from 'react-native-html-to-pdf';
 import RNMail from 'react-native-mail';
 // there's a version of RNMail @ https://github.com/parkerdan/react-native-mail
 // that removes the NativeModules dependency
 
-var HTMLToPDFExample = React.createClass({
+class HTMLToPDFExample extends Component {
 
   componentDidMount() {
     var options = {
@@ -27,20 +27,20 @@ var HTMLToPDFExample = React.createClass({
       fileName: 'test'
     };
 
-  RNHTMLtoPDF.convert(options).then((result) => {
-    RNMail.mail({
-        subject: '',
-        recipients: [''],
-        body: '',
-        attachmentPath: result,
-        attachmentType: 'pdf',
+    RNHTMLtoPDF.convert(options).then((data) => {
+      RNMail.mail({
+         subject: '',
+         recipients: [''],
+         body: '',
+         attachmentPath: data.filePath,
+         attachmentType: 'pdf',
       }, (error, event) => {
-        if(error) {
+        if (error) {
           AlertIOS.alert('Error', 'Could not send mail. Please send a mail to support@example.com');
         }
       });
     });
-  },
+  }
 
   render() {
     return (
@@ -58,9 +58,9 @@ var HTMLToPDFExample = React.createClass({
       </View>
     );
   }
-});
+}
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',

--- a/HTMLToPDFExample/index.ios.js
+++ b/HTMLToPDFExample/index.ios.js
@@ -4,22 +4,22 @@
  */
 'use strict';
 
-import React, { Component } from 'react';
+var React = require('react-native');
 
-import {
+var {
+  AlertIOS,
   AppRegistry,
   StyleSheet,
-  AlertIOS,
   Text,
   View,
-} from 'react-native';
+} = React;
 
 import RNHTMLtoPDF from 'react-native-html-to-pdf';
 import RNMail from 'react-native-mail';
 // there's a version of RNMail @ https://github.com/parkerdan/react-native-mail
 // that removes the NativeModules dependency
 
-class HTMLToPDFExample extends Component {
+var HTMLToPDFExample = React.createClass({
 
   componentDidMount() {
     var options = {
@@ -27,20 +27,20 @@ class HTMLToPDFExample extends Component {
       fileName: 'test'
     };
 
-    RNHTMLtoPDF.convert(options).then((data) => {
-      RNMail.mail({
-         subject: '',
-         recipients: [''],
-         body: '',
-         attachmentPath: data.filePath,
-         attachmentType: 'pdf',
+  RNHTMLtoPDF.convert(options).then((data) => {
+    RNMail.mail({
+        subject: '',
+        recipients: [''],
+        body: '',
+        attachmentPath: data.filePath,
+        attachmentType: 'pdf',
       }, (error, event) => {
-        if (error) {
+        if(error) {
           AlertIOS.alert('Error', 'Could not send mail. Please send a mail to support@example.com');
         }
       });
     });
-  }
+  },
 
   render() {
     return (
@@ -58,9 +58,9 @@ class HTMLToPDFExample extends Component {
       </View>
     );
   }
-}
+});
 
-const styles = StyleSheet.create({
+var styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The android module pulls in iText to convert html to pdf.  You are supposed to o
 
 ```java
 include ':react-native-html-to-pdf'
-project(':react-native-html-to-pdf').projectDir = new File(rootProject.projectDir,'../node_modules/rreact-native-html-to-pdf/android')
+project(':react-native-html-to-pdf').projectDir = new File(rootProject.projectDir,'../node_modules/react-native-html-to-pdf/android')
 ```
 
 - Edit `android/app/build.gradle` file to include

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ var Example = React.createClass({
       directory: 'docs'          /* Optional: 'docs' will save the file in the `Documents`
                                     Default: Temp directory
                                   */
-
+      base64: true               /* Optional: get the base64 PDF value
+                                    Default: false
+                                 */
       height: 800                /* Optional: 800 sets the height of the DOCUMENT that will be produced
                                     Default: 612
                                   */
@@ -54,9 +56,11 @@ var Example = React.createClass({
                                   */
     };
 
-    RNHTMLtoPDF.convert(options).then((filePath) => {
-      console.log(filePath);
+    RNHTMLtoPDF.convert(options).then((data) => {
+      console.log(data.filePath);
+      console.log(data.base64);
     });
+                                  // data.base64 will be empty if base64 is set to false
   },
 
   render() {

--- a/RNHTMLtoPDF/RNHTMLtoPDF.m
+++ b/RNHTMLtoPDF/RNHTMLtoPDF.m
@@ -42,6 +42,7 @@
     CGSize _PDFSize;
     UIWebView *_webView;
     float _padding;
+    BOOL _base64;
     BOOL autoHeight;
 }
 
@@ -83,6 +84,12 @@ RCT_EXPORT_METHOD(convert:(NSDictionary *)options
         _filePath = [NSString stringWithFormat:@"%@%@.pdf", NSTemporaryDirectory(), _fileName];
     }
 
+    if (options[@"base64"] && [options[@"base64"] boolValue]) {
+        _base64 = true;   
+    } else {
+        _base64 = false;   
+    }
+    
     if (options[@"height"] && options[@"width"]) {
         float width = [RCTConvert float:options[@"width"]];
         float height = [RCTConvert float:options[@"height"]];
@@ -126,8 +133,16 @@ RCT_EXPORT_METHOD(convert:(NSDictionary *)options
     NSData *pdfData = [render printToPDF];
 
     if (pdfData) {
+        NSString *pdfBase64 = @"";
+        
         [pdfData writeToFile:_filePath atomically:YES];
-        _resolveBlock(_filePath);
+        if (_base64) {
+            pdfBase64 = [pdfData base64EncodedStringWithOptions:0];   
+        }
+        NSDictionary *data = [NSDictionary dictionaryWithObjectsAndKeys:
+                             pdfBase64, @"base64",
+                             _filePath, @"filePath", nil];
+        _resolveBlock(data);
     } else {
         NSError *error;
         _rejectBlock(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));


### PR DESCRIPTION
Maybe it's more clear if we only return the filePath string if base64 is set to false instead of a NSDictionary containing an empty string for the base64. What is the best solution ?
