### PR TITLE
Fix typo in android example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The android module pulls in iText to convert html to pdf.  You are supposed to o
 
 ```java
 include ':react-native-html-to-pdf'
-project(':react-native-html-to-pdf').projectDir = new File(rootProject.projectDir,'../node_modules/rreact-native-html-to-pdf/android')
+project(':react-native-html-to-pdf').projectDir = new File(rootProject.projectDir,'../node_modules/react-native-html-to-pdf/android')
 ```
 
 - Edit `android/app/build.gradle` file to include


### PR DESCRIPTION
Fixes a small typo in the `node_modules` path inside the android example