### PR TITLE
Android hotfix for wrong package name

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.parkerdan.htmltopdf">
+          package="com.christopherdro.htmltopdf">
 </manifest>


### PR DESCRIPTION
The wrong package name in the AndroidManifest.xml made `react-native link` link a wrong package name and the build process fail.

See #33 

Rerun the manual installation process and it should work fine after.