### PR TITLE
fix options default values in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ class Example extends Component {
 
 | Param | Type | Default | Note |
 |---|---|---|---|
-| `height` | number | 612  | Set document height (points)
-| `width` | number | 792  | Set document width (points)
+| `height` | number | 792  | Set document height (points)
+| `width` | number | 612  | Set document width (points)
 | `padding` | number | 10  | Outer padding (points)
 
 


### PR DESCRIPTION
options default values are inverted:

https://github.com/christopherdro/react-native-html-to-pdf/blob/master/ios/RNHTMLtoPDF/RNHTMLtoPDF.m

l12

```objective-c
#define PDFSize CGSizeMake(612,792)
```

width then height

https://developer.apple.com/documentation/coregraphics/1455082-cgsizemake