### PR TITLE
fixed android docs directory before SDK 19

### DIFF
--- a/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
+++ b/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
@@ -44,9 +44,17 @@ public class RNHTMLtoPDFModule extends ReactContextBaseJavaModule {
 
       if (options.hasKey("directory") && options.getString("directory").equals("docs")) {
         String state = Environment.getExternalStorageState();
-          File path = (Environment.MEDIA_MOUNTED.equals(state)) ?
-                  new File(Environment.getExternalStorageDirectory(), Environment.DIRECTORY_DOCUMENTS)
-                  : new File(mReactContext.getFilesDir(), Environment.DIRECTORY_DOCUMENTS);
+
+        String directoryPath;
+        if (Integer.valueOf(android.os.Build.VERSION.SDK) >= 19) {
+          documentsPath = Environment.DIRECTORY_DOCUMENTS;
+        } else {
+          documentsPath = Environment.getExternalStorageDirectory() + "/Documents");
+        }
+
+        File path = (Environment.MEDIA_MOUNTED.equals(state)) ?
+                new File(Environment.getExternalStorageDirectory(), documentsPath)
+                : new File(mReactContext.getFilesDir(), documentsPath);
 
         if (!path.exists()) path.mkdir();
         destinationFile = new File(path, fileName + ".pdf");

--- a/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
+++ b/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
@@ -45,7 +45,7 @@ public class RNHTMLtoPDFModule extends ReactContextBaseJavaModule {
       if (options.hasKey("directory") && options.getString("directory").equals("docs")) {
         String state = Environment.getExternalStorageState();
 
-        String directoryPath;
+        String documentsPath;
         if (Integer.valueOf(android.os.Build.VERSION.SDK) >= 19) {
           documentsPath = Environment.DIRECTORY_DOCUMENTS;
         } else {

--- a/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
+++ b/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
@@ -49,7 +49,7 @@ public class RNHTMLtoPDFModule extends ReactContextBaseJavaModule {
         if (Integer.valueOf(android.os.Build.VERSION.SDK) >= 19) {
           documentsPath = Environment.DIRECTORY_DOCUMENTS;
         } else {
-          documentsPath = Environment.getExternalStorageDirectory() + "/Documents");
+          documentsPath = Environment.getExternalStorageDirectory() + "/Documents";
         }
 
         File path = (Environment.MEDIA_MOUNTED.equals(state)) ?


### PR DESCRIPTION
Hello,
 
`Environment.DIRECTORY_DOCUMENTS` has been [introduced in API 19](https://developer.android.com/reference/android/os/Environment.html#DIRECTORY_DOCUMENTS) so this package breaks for devices before API 19.

This fixes the bug

`Caused by java.lang.NoSuchFieldError
android.os.Environment.DIRECTORY_DOCUMENTS`