### PR TITLE
fix syntax of example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ import {
   Text,
   TouchableHighlight,
   View,
-} = from 'react-native';
+} from 'react-native';
 
 import RNHTMLtoPDF from 'react-native-html-to-pdf';
 
-class Example extends Component {
+export default class Example extends Component {
   async createPDF() {
     let options = {
       html: '<h1>PDF TEST</h1>',
@@ -69,15 +69,18 @@ class Example extends Component {
     };
 
     let file = await RNHTMLtoPDF.convert(options)
-    console.log(file.filePath);
-  },
+    // console.log(file.filePath);
+    alert(file.filePath);
+  }
 
   render() {
-    <View>
-      <TouchableHighlight onPress={this.createPDF}>
-        <Text>Create PDF</Text>
-      </TouchableHighlight>
-    </View>
+    return(
+      <View>
+        <TouchableHighlight onPress={this.createPDF}>
+          <Text>Create PDF</Text>
+        </TouchableHighlight>
+      </View>
+    )
   }
 }
 ```


### PR DESCRIPTION
1. render method should return those components
2. don't use `=` with `import and `from`
3. export default the class 

