### PR TITLE
Fix issue with getTempFile not using provided fileName

### DIFF
--- a/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
+++ b/android/src/main/java/com/christopherdro/htmltopdf/RNHTMLtoPDFModule.java
@@ -39,7 +39,7 @@ public class RNHTMLtoPDFModule extends ReactContextBaseJavaModule {
       if (options.hasKey("fileName")) {
         fileName = options.getString("fileName");
       } else {
-        fileName = UUID.randomUUID().toString();
+        fileName = "PDF_" + UUID.randomUUID().toString();
       }
 
       if (options.hasKey("directory") && options.getString("directory").equals("docs")) {
@@ -77,7 +77,7 @@ public class RNHTMLtoPDFModule extends ReactContextBaseJavaModule {
   private File getTempFile(String fileName) throws Exception {
     try {
       File outputDir = getReactApplicationContext().getCacheDir();
-      File outputFile = File.createTempFile("PDF_" + UUID.randomUUID().toString(), ".pdf", outputDir);
+      File outputFile = File.createTempFile(fileName, ".pdf", outputDir);
 
       return outputFile;
 


### PR DESCRIPTION
Hi guys, I've been using your library it's been working great so a big thanks first!

Here's an issue I thought should be fixed
## Issue
getTempFile isn't using fileName in its arg, hence, providing a fileName in options has no effect if you do not provide a directory. This doesn't seem intentional.

## Changes
* fileName has already been initialised with uuid in convert method, so use it, and add prefix of fileName there