### PR TITLE
To solve ReleaseBuild Error for verifyreleaseresources failed to execute aapt

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,15 @@ export default class Example extends Component {
 | Param | Type | Default | Note |
 |---|---|---|---|
 | `fonts` | Array | | Allow custom fonts `['/fonts/TimesNewRoman.ttf', '/fonts/Verdana.ttf']`
+
+### Issues ( The reason to fork and pull request )
+
+```js
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':react-native-html-to-pdf:verifyReleaseResources'.
+> com.android.ide.common.process.ProcessException: Failed to execute aapt
+```
+Check the issue if you are facing same problem on release build:
+https://github.com/christopherdro/react-native-html-to-pdf/issues/98

--- a/README.md
+++ b/README.md
@@ -114,14 +114,3 @@ export default class Example extends Component {
 |---|---|---|---|
 | `fonts` | Array | | Allow custom fonts `['/fonts/TimesNewRoman.ttf', '/fonts/Verdana.ttf']`
 
-### Issues ( The reason to fork and pull request )
-
-```js
-FAILURE: Build failed with an exception.
-
-* What went wrong:
-Execution failed for task ':react-native-html-to-pdf:verifyReleaseResources'.
-> com.android.ide.common.process.ProcessException: Failed to execute aapt
-```
-Check the issue if you are facing same problem on release build:
-https://github.com/christopherdro/react-native-html-to-pdf/issues/98

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,38 +1,22 @@
 
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
-    }
-}
-
-
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 25)
+    buildToolsVersion safeExtGet('buildToolsVersion', "25.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
-        ndk {
-            abiFilters "armeabi-v7a", "x86"
-        }
     }
 }
 
-repositories {
-    mavenCentral()
-}
-
-
 dependencies {
-    compile 'com.tom_roush:pdfbox-android:1.8.10.0'
     compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.christopherdro.htmltopdf">
+          package="com.christopherdro.htmltopdf"
+    >
 </manifest>


### PR DESCRIPTION
![screenshot_3](https://user-images.githubusercontent.com/10045253/50816364-8d430c80-134a-11e9-8a14-cee3cecefd8f.png)
When you are going do a `releaseBuild` you will see this issue,  I was juggling with it for more than 4 hours. as I'm not a android developer by itself. So it was too hard for me to figure out the issue, Then i was thinking what could be the issue. It was very simple! Then I tried to collect information about releasing a package and all that . then compared with a valid package. and got the culprit! 

```js
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-html-to-pdf:verifyReleaseResources'.
> com.android.ide.common.process.ProcessException: Failed to execute aapt
```

Please merge and pull this package ASAP it's so frustrating stuff.
