### PR TITLE
Change compile to implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,6 @@ repositories {
 
 
 dependencies {
-    compile 'com.tom_roush:pdfbox-android:1.8.10.0'
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.tom_roush:pdfbox-android:1.8.10.0'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation'.