### PR TITLE
fixed images on Android

### DIFF
--- a/android/src/main/java/android/print/PdfConverter.java
+++ b/android/src/main/java/android/print/PdfConverter.java
@@ -96,7 +96,7 @@ public class PdfConverter implements Runnable {
         });
         WebSettings settings = mWebView.getSettings();
         settings.setDefaultTextEncodingName("utf-8");
-        mWebView.loadData(mHtmlString, "text/HTML; charset=utf-8", null);
+        mWebView.loadDataWithBaseURL(mBaseURL, mHtmlString, "text/HTML", "utf-8", null);
     }
 
     public PrintAttributes getPdfPrintAttrs() {


### PR DESCRIPTION
Method **loadData**  doesn't allow to load images with "file://" urls from application internal storage.
With method **loadDataWithBaseURL** images do load.
Also method  **loadDataWithBaseURL** works fine with RTL text
So I believe it is better to use **loadDataWithBaseURL**