### PR TITLE
Fix podspec: add v in front of version number in the podspec tag

### DIFF
--- a/react-native-html-to-pdf.podspec
+++ b/react-native-html-to-pdf.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/christopherdro/react-native-html-to-pdf.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/christopherdro/react-native-html-to-pdf.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
`pod install` will not work at the moment because it tries to find a tag named `0.8.0` but you always have a `v` in front of the version tags. So we have to upgrade the `podspec` accordingly.