### PR TITLE
Update property extension

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-     ext {
+     rootProject.ext {
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28


### PR DESCRIPTION
v0.8.0 is failing the build on Android due to `Cannot get property 'compileSdkVersion' on extra properties extension as it does not exist`

In the change here, we modify the extension to the expected one. 