### PR TITLE
Add storage permission section for Android on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ new MainReactPackage(),
 new RNHTMLtoPDFPackage()
 ```
 
+- Add the following `WRITE_EXTERNAL_STORAGE` permission to `AndroidManifest.xml`
+
+```xml
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+```
+Also starting from Android M, users need to be prompted for permission dynamically. Follow [this](https://facebook.github.io/react-native/docs/permissionsandroid) link for more details on how to do that.
+
+
 ## Usage
 ```javascript
 


### PR DESCRIPTION
On Android the app keeps crashing because storage permission was not added. So I added the instructions to add storage permission to manifest file. This way when anyone trying the sample codes from readme, it'll not result in a crash.