### PR TITLE
Fixed the issue with pdf generation when error is returned from pdf module this library is using

### DIFF
--- a/android/src/main/java/android/print/PdfConverter.java
+++ b/android/src/main/java/android/print/PdfConverter.java
@@ -90,6 +90,22 @@ public class PdfConverter implements Runnable {
                                 destroy();
                             }
                         }
+
+                        @Override
+                        public void onWriteFailed(CharSequence error) {
+                            String errorResult = "Please retry, Error occurred generating the pdf";
+                            if (error != null) {
+                                errorResult = error.toString();
+                            }
+                            mPromise.reject(errorResult);
+                            destroy();
+                        }
+
+                        @Override
+                        public void onWriteCancelled() {
+                            destroy();
+                        }
+
                     });
                 }
             }


### PR DESCRIPTION
### What?
This pull request fixes the issue when error is returned from pdf module.  

### Why?
when user tries generated pdf `mIsCurrentlyConverting` variable becomes true and error is thrown from library, it never becomes false again, It is because this library is not handling error returned from module correctly. 

so due to 
```java
        if (mIsCurrentlyConverting)
            return;

```
Library never tried to generate pdf again and promise stays in pending state.

### How?

After looking at [PdfDocumentAdapter](https://developer.android.com/reference/android/print/PrintDocumentAdapter). I found out that Library has two methods `onWriteFailed` and `onWriteCancelled`. I started using these and returning error when pdf generation fails and call `destroy()` method to unset the flag mIsCurrentlyConverting to false. 
```java
     @Override
                        public void onWriteFailed(CharSequence error) {
                            String errorResult = "Please retry, Error occurred generating the pdf";
                            if (error != null) {
                                errorResult = error.toString();
                            }
                            mPromise.reject(errorResult);
                            destroy();
                        }

                        @Override
                        public void onWriteCancelled() {
                            destroy();
                        }
```


### Anything Else?
This fixes the issue with promise staying in pending state, and returns the error gracefully. 

**Request from library maintainer** 
Please fix the issue of .apk size getting increased by 5mb, otherwise this works nicely. 
There is one fork of this [Library by Onibenjp](https://github.com/Onibenjo/react-native-html-to-pdf) which fixes the size issue. But I think there is more scope to this. Please merge the changes from this library. There is no point of having many libraries solving same problem. 