### PR TITLE
[Android] Prevent WebView from changing font-size

### DIFF
--- a/android/src/main/java/android/print/PdfConverter.java
+++ b/android/src/main/java/android/print/PdfConverter.java
@@ -111,6 +111,7 @@ public class PdfConverter implements Runnable {
             }
         });
         WebSettings settings = mWebView.getSettings();
+        settings.setTextZoom(100);
         settings.setDefaultTextEncodingName("utf-8");
         mWebView.loadDataWithBaseURL(mBaseURL, mHtmlString, "text/HTML", "utf-8", null);
     }


### PR DESCRIPTION
WebView respects the system font size setting (which can be altered at: Settings > Display > Font size).
This changes the appearance of the texts when they are printed, which does not seem to be a desirable behavior.