### PR TITLE
Removed jCenter dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.1'
@@ -42,6 +42,6 @@ repositories {
 
 
 dependencies {
-    implementation 'com.tom_roush:pdfbox-android:1.8.10.0'
+    implementation 'com.tom-roush:pdfbox-android:1.8.10.3'
     implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Because latest react native does not include jCenter as repository source the build will fail: https://github.com/christopherdro/react-native-html-to-pdf/issues/235
Removed jcenter as repository source and update the `pdfbox-android` dependency to use the one from mavenCentral